### PR TITLE
アクセス制限

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,8 @@
 class PrototypesController < ApplicationController
-  
+  before_action :set_prototype, except: [:index, :new, :create]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy]
+
   def index
     @prototypes = Prototype.all
   end
@@ -48,5 +51,11 @@ class PrototypesController < ApplicationController
     params.require(:prototype).permit(:title, :text, :concept, :appli, :github, :image).merge(user_id: current_user.id)
   end
 
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
+  end
 
+  def contributor_confirmation
+    redirect_to root_path unless current_user == @prototype.user
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
           </div>
             <div class="nav__right">
             <% if user_signed_in? %>
-              <%= link_to "プロフィール", user_path(current_user.id), class: :greeting__link%>
+              <%= link_to "ログイン中", user_path(current_user.id), class: :greeting__link%>
               <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: :nav__logout %>
               <%= link_to "アプリ投稿", new_prototype_path, class: :nav__btn %>
             </div>


### PR DESCRIPTION
#What（どのような実装をしているのか）
コントローラーに、authenticate_user!を用いて制限を設けた
投稿者以外がeditアクションにアクセスしたらトップページにリダイレクトするように記述した

#Why（なぜこの実装が必要なのか）
ログインしていないユーザーのページ遷移を制限するため
投稿者以外のユーザーが、投稿者専用のページに遷移できないようにするため