### PR TITLE
アクセス範囲の制限

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,8 @@
 class BooksController < ApplicationController
-
+  before_action :set_book, except: [:index, :new, :create]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy]
+  
   def index
     @books = Book.all
   end
@@ -44,6 +47,14 @@ class BooksController < ApplicationController
   private
   def book_params
     params.require(:book).permit(:title, :reed, :understand, :text, :action, :link, :image).merge(user_id: current_user.id)
+  end
+
+  def set_book
+    @book = Book.find(params[:id])
+  end
+
+  def contributor_confirmation
+    redirect_to root_path unless current_user == @book.user
   end
 
 end


### PR DESCRIPTION
#What（どのような実装をしているのか）
コントローラーに、authenticate_user!を用いて制限を設けた
投稿者以外がeditアクションにアクセスしたらトップページにリダイレクトするように記述した

#Why（なぜこの実装が必要なのか）
ログインしていないユーザーのページ遷移を制限するため
投稿者以外のユーザーが、投稿者専用のページに遷移できないようにするため